### PR TITLE
Alias `fluct g` to `fluct generate`

### DIFF
--- a/bin/fluct
+++ b/bin/fluct
@@ -18,6 +18,7 @@ program
 
 program
   .command('generate')
+  .alias('g')
   .arguments('<generator>')
   .arguments('<name>')
   .description('Generate a new resource')


### PR DESCRIPTION
After this change, the command usage looks like this:

```
$ fluct -h

  Usage: fluct [options] [command]

  Commands:

    deploy                         Deploy functions to AWS
    generate|g <generator> <name>  Generate a new resource
    new <name>                     Generate a new application
    routes                         List all routes
    server [options]               Launch a web server

  Options:

    -h, --help  output usage information
```

Close https://github.com/r7kamura/fluct/issues/8
