### PR TITLE
Add dependency ejs package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "amazon-api-gateway-client": "^0.1.2",
     "aws-sdk": "^2.1.44",
     "commander": "^2.8.1",
+    "ejs": "^2.3.3",
     "express": "^4.13.3",
     "glob": "^5.0.14",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Fluct new command can't execute on my macbook. It seems to be lack of dependency to ejs package.
Here is output logs.

```
$ npm install -g fluct
/usr/local/bin/fluct -> /usr/local/lib/node_modules/fluct/bin/fluct
fluct@0.2.0 /usr/local/lib/node_modules/fluct
├── commander@2.8.1 (graceful-readlink@1.0.1)
├── yazl@2.2.2 (buffer-crc32@0.2.5)
├── node-aws-lambda@0.1.4 (async@1.4.2)
├── mkdirp@0.5.1 (minimist@0.0.8)
├── glob@5.0.14 (path-is-absolute@1.0.0, inherits@2.0.1, once@1.3.2, inflight@1.0.4, minimatch@2.0.10)
├── express@4.13.3 (escape-html@1.0.2, merge-descriptors@1.0.0, cookie@0.1.3, array-flatten@1.1.1, methods@1.1.1, utils-merge@1.0.0, cookie-signature@1.0.6, fresh@0.3.0, range-parser@1.0.2, vary@1.0.1, path-to-regexp@0.1.7, content-type@1.0.1, etag@1.7.0, parseurl@1.3.0, content-disposition@0.5.0, serve-static@1.10.0, depd@1.0.1, finalhandler@0.4.0, on-finished@2.3.0, qs@4.0.0, debug@2.2.0, proxy-addr@1.0.8, send@0.13.0, type-is@1.6.6, accepts@1.2.12)
├── amazon-api-gateway-client@0.1.2 (stackable-fetcher-aws-signer-v4@0.0.1, stackable-fetcher@0.3.0)
└── aws-sdk@2.1.44 (xmlbuilder@0.4.2, xml2js@0.2.8, sax@0.5.3)
$ fluct new apisample
module.js:338
    throw err;
          ^
Error: Cannot find module 'ejs'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/fluct/lib/base_command.js:13:12)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
```
