### PR TITLE
[fix] Escape params in mapping template of API Gateway

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -94,19 +94,19 @@ export default class Action {
         "caller": "$context.identity.caller",
         "headers": {
       #foreach( $key in $input.params().header.keySet() )
-          "$key": "$input.params().header.get($key)"#if( $foreach.hasNext ),#end
+          "$key": "$util.escapeJavaScript($input.params().header.get($key))"#if( $foreach.hasNext ),#end
       #end
         },
         "httpMethod": "$context.httpMethod",
         "path": "$context.resourcePath",
         "pathParameters": {
       #foreach( $key in $input.params().path.keySet() )
-          "$key": "$input.params().path.get($key)"#if( $foreach.hasNext ),#end
+          "$key": "$util.escapeJavaScript($input.params().path.get($key))"#if( $foreach.hasNext ),#end
       #end
         },
         "queryParameters": {
       #foreach( $key in $input.params().querystring.keySet() )
-          "$key": "$input.params().querystring.get($key)"#if( $foreach.hasNext ),#end
+          "$key": "$util.escapeJavaScript($input.params().querystring.get($key))"#if( $foreach.hasNext ),#end
       #end
         },
         "requestId": "$context.requestId",


### PR DESCRIPTION
If we pass the invalid JavaScript parameters, API Gateway will return error below.

``` json
{
  "Type": "User",
  "message": "Could not parse request body into json."
}
```

So, we need to escape in mapping template.
