### PR TITLE
Add lambda func arn in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ $ cat actions/list_users/package.json
   "name": "list_users",
   "private": true,
   "fluct": {
+    "arn": "arn:aws:lambda:us-east-1:549958975024:function:foo",
     "contentType": "text/html",
     "httpMethod": "GET",
     "path": "/users",


### PR DESCRIPTION
Make it explicit in the code snippet how to provide a reference to a lambda function, which is possibly the most common use case. This isn't clear at the moment and one has to go look for other sample code, i.e. the fluct-example repo
