### PR TITLE
Use aws-sdk-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "gulp-mocha": "^2.1.3"
   },
   "dependencies": {
-    "amazon-api-gateway-client": "^0.1.3",
     "aws-sdk": "^2.1.44",
     "commander": "^2.8.1",
     "config": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.1.44",
+    "aws-sdk-promise": "^0.0.2",
     "commander": "^2.8.1",
     "config": "^1.15.0",
     "ejs": "^2.3.3",

--- a/src/application.js
+++ b/src/application.js
@@ -99,8 +99,8 @@ export default class Application {
   /**
    * @return {String}
    */
-  getRestapiId() {
-    return this.getPackage().fluct.restapiId;
+  getRestApiId() {
+    return this.getPackage().fluct.restApiId;
   }
 
   /**
@@ -126,11 +126,11 @@ export default class Application {
   }
 
   /**
-   * @param {String} restapiId
+   * @param {String} restApiId
    */
-  writeRestapiId(restapiId) {
+  writeRestApiId(restApiId) {
     const metadata = this.getMetadata();
-    metadata.fluct.restapiId = restapiId;
+    metadata.fluct.restApiId = restApiId;
     fs.writeSync(
       fs.openSync('./package.json', 'w'),
       JSON.stringify(metadata, null, 2)

--- a/src/composer.js
+++ b/src/composer.js
@@ -314,6 +314,31 @@ export default class Composer extends EventEmitter {
         }).promise()
       }
     })().then((method) => {
+      let foundMethodResponse;
+      if (method.data.methodResponses) {
+        foundMethodResponse = Object.keys(method.data.methodResponses).find((methodResponse) => {
+          return methodResponse.toString() === action.getStatusCode().toString();
+        });
+      } else {
+        foundMethodResponse = false;
+      }
+      if (foundMethodResponse) {
+        return this.getClient().getMethodResponse({
+          httpMethod: action.getHttpMethod(),
+          resourceId: resource.id,
+          restApiId: restApiId,
+          statusCode: action.getStatusCode().toString()
+        }).promise();
+      } else {
+        return this.getClient().putMethodResponse({
+          httpMethod: action.getHttpMethod(),
+          resourceId: resource.id,
+          responseModels: action.getResponseModels(),
+          restApiId: restApiId,
+          statusCode: action.getStatusCode().toString()
+        }).promise();
+      }
+    }).then((methodResponse) => {
       return this.getClient().putIntegration({
         httpMethod: action.getHttpMethod(),
         integrationHttpMethod: 'POST',
@@ -322,14 +347,6 @@ export default class Composer extends EventEmitter {
         restApiId: restApiId,
         type: 'AWS',
         uri: action.getUri()
-      }).promise();
-    }).then((integration) => {
-      return this.getClient().putMethodResponse({
-        httpMethod: action.getHttpMethod(),
-        resourceId: resource.id,
-        responseModels: action.getResponseModels(),
-        restApiId: restApiId,
-        statusCode: action.getStatusCode().toString()
       }).promise();
     }).then(() => {
       return this.getClient().putIntegrationResponse({

--- a/src/composer.js
+++ b/src/composer.js
@@ -107,6 +107,7 @@ export default class Composer extends EventEmitter {
         };
       }).reduce((promise, task) => {
         return promise.then(task).then((resource) => {
+          existingResources.push(resource.data);
           return resource.data;
         });
       }, Promise.resolve(existingParentResource));

--- a/src/composer.js
+++ b/src/composer.js
@@ -288,7 +288,7 @@ export default class Composer extends EventEmitter {
    * @return {Promise}
    */
   updateMethodSet({ region, restApiId, action, resource }) {
-    (() => {
+    return (() => {
       let foundMethod;
       if (resource.resourceMethods) {
         foundMethod = Object.keys(resource.resourceMethods).find((method) => {

--- a/src/composer.js
+++ b/src/composer.js
@@ -252,7 +252,15 @@ export default class Composer extends EventEmitter {
   findOrCreateRestApi() {
     const restApiId = this.application.getRestApiId();
     if (restApiId) {
-      return this.getClient().getRestApi({ restApiId: restApiId }).promise();
+      return this.getClient().getRestApi({
+        restApiId: restApiId
+      }).promise().then((restApi) => {
+        return restApi;
+      }).catch((reason) => {
+        if (reason.code === 'NotFoundException') {
+          return this.createRestApi();
+        }
+      });
     } else {
       return this.createRestApi();
     }

--- a/src/composer.js
+++ b/src/composer.js
@@ -189,7 +189,7 @@ export default class Composer extends EventEmitter {
    */
   getClient() {
     if (!this.client) {
-      this.client = new Client({
+      this.client = new AWS.APIGateway({
         accessKeyId: this.accessKeyId,
         secretAccessKey: this.secretAccessKey,
         region: this.application.getRegion()

--- a/src/composer.js
+++ b/src/composer.js
@@ -70,7 +70,7 @@ export default class Composer extends EventEmitter {
   }
 
   /**
-   * @param {Array.<Object>} resources
+   * @param {Array.<Object>} existingResources
    * @param {String} path
    * @return {Promise}
    */
@@ -86,7 +86,9 @@ export default class Composer extends EventEmitter {
   }
 
   /**
+   * @param {Array.<Object>} existingResources
    * @param {String} restApiId
+   * @param {String} path
    * @return {Promise}
    */
   createResourceWithRecursivePath({ existingResources, restApiId, path }) {

--- a/src/composer.js
+++ b/src/composer.js
@@ -280,12 +280,21 @@ export default class Composer extends EventEmitter {
    * @return {Promise}
    */
   updateMethodSet({ region, restApiId, action, resource }) {
-    return this.getClient().putMethod({
-      authorizationType: 'NONE',
-      httpMethod: action.getHttpMethod(),
-      resourceId: resource.id,
-      restApiId: restApiId
-    }).promise().then((resource) => {
+    (() => {
+      let foundMethod = Object.keys(resource.resourceMethods).find((method) => {
+        return method === action.getHttpMethod();
+      });
+      if (foundMethod) {
+        return Promise.resolve(resource.resourceMethods[foundMethod]);
+      } else {
+        return this.getClient().putMethod({
+          authorizationType: 'NONE',
+          httpMethod: action.getHttpMethod(),
+          resourceId: resource.id,
+          restApiId: restApiId
+        }).promise()
+      }
+    })().then((method) => {
       return this.getClient().putIntegration({
         httpMethod: action.getHttpMethod(),
         integrationHttpMethod: 'POST',

--- a/src/composer.js
+++ b/src/composer.js
@@ -119,13 +119,15 @@ export default class Composer extends EventEmitter {
     return this.getClient().getResources({
       restApiId: restApiId
     }).promise().then((resources) => {
+      let resources = resources.data.items;
       return this.application.getActions().map((action) => {
         return () => {
           return this.createResourceWithRecursivePath({
-            existingResources: resources.data.items,
+            existingResources: resources,
             restApiId: restApiId,
             path: action.getPath()
           }).then((resource) => {
+            resources.push(resource);
             return {
               action: action,
               resource: resource

--- a/src/composer.js
+++ b/src/composer.js
@@ -237,7 +237,7 @@ export default class Composer extends EventEmitter {
       return this.createResourceSets({
         restApiId: restApi.data.id
       }).then(() => {
-        return restApi;
+        return restApi.data;
       });
     }).then((restApi) => {
       this.createDeployment({

--- a/src/composer.js
+++ b/src/composer.js
@@ -326,17 +326,12 @@ export default class Composer extends EventEmitter {
       return new Promise((resolve, reject) => {
         new AWS.Lambda({
           region: region
-        }).addPermission(
-          {
-            Action: 'lambda:InvokeFunction',
-            FunctionName: functionName,
-            Principal: 'apigateway.amazonaws.com',
-            StatementId: crypto.randomBytes(20).toString('hex')
-          },
-          (error, data) => {
-            resolve();
-          }
-        );
+        }).addPermission({
+          Action: 'lambda:InvokeFunction',
+          FunctionName: functionName,
+          Principal: 'apigateway.amazonaws.com',
+          StatementId: crypto.randomBytes(20).toString('hex')
+        }).promise();
       })
     }).then((value) => {
       this.emit(

--- a/src/composer.js
+++ b/src/composer.js
@@ -289,9 +289,14 @@ export default class Composer extends EventEmitter {
    */
   updateMethodSet({ region, restApiId, action, resource }) {
     (() => {
-      let foundMethod = Object.keys(resource.resourceMethods).find((method) => {
-        return method === action.getHttpMethod();
-      });
+      let foundMethod;
+      if (resource.resourceMethods) {
+        foundMethod = Object.keys(resource.resourceMethods).find((method) => {
+          return method === action.getHttpMethod();
+        });
+      } else {
+        foundMethod = false;
+      }
       if (foundMethod) {
         return Promise.resolve(resource.resourceMethods[foundMethod]);
       } else {

--- a/src/composer.js
+++ b/src/composer.js
@@ -150,7 +150,9 @@ export default class Composer extends EventEmitter {
             action: item.action
           });
         })
-      );
+      ).then(() => {
+        return restApiId;
+      });
     });
   }
 

--- a/src/composer.js
+++ b/src/composer.js
@@ -119,7 +119,7 @@ export default class Composer extends EventEmitter {
     return this.getClient().getResources({
       restApiId: restApiId
     }).promise().then((resources) => {
-      let resources = resources.data.items;
+      resources = resources.data.items;
       return this.application.getActions().map((action) => {
         return () => {
           return this.createResourceWithRecursivePath({

--- a/src/composer.js
+++ b/src/composer.js
@@ -1,4 +1,4 @@
-import AWS from 'aws-sdk'
+import AWS from 'aws-sdk-promise'
 import awsLambda from 'node-aws-lambda'
 import crypto from 'crypto'
 import fs from 'fs'

--- a/src/composer.js
+++ b/src/composer.js
@@ -300,7 +300,11 @@ export default class Composer extends EventEmitter {
         foundMethod = false;
       }
       if (foundMethod) {
-        return Promise.resolve(resource.resourceMethods[foundMethod]);
+        return this.getClient().getMethod({
+          httpMethod: action.getHttpMethod(),
+          resourceId: resource.id,
+          restApiId: restApiId
+        }).promise()
       } else {
         return this.getClient().putMethod({
           authorizationType: 'NONE',

--- a/src/composer.js
+++ b/src/composer.js
@@ -312,7 +312,7 @@ export default class Composer extends EventEmitter {
         resourceId: resourceId,
         responseModels: responseModels,
         restApiId: restApiId,
-        statusCode: statusCode
+        statusCode: statusCode.toString()
       }).promise();
     }).then(() => {
       return this.getClient().putIntegrationResponse({
@@ -320,7 +320,7 @@ export default class Composer extends EventEmitter {
         resourceId: resourceId,
         responseTemplates: responseTemplates,
         restApiId: restApiId,
-        statusCode: statusCode
+        statusCode: statusCode.toString()
       }).promise();
     }).then(() => {
       return new Promise((resolve, reject) => {

--- a/src/composer.js
+++ b/src/composer.js
@@ -57,7 +57,7 @@ export default class Composer extends EventEmitter {
       resolve(resources.sort((a, b) => {
         /* sort descending */
         let aPathDepth = a.path.split('/').filter((dir) => { return dir !== '' }).length;
-        let bPathDepth = a.path.split('/').filter((dir) => { return dir !== '' }).length;
+        let bPathDepth = b.path.split('/').filter((dir) => { return dir !== '' }).length;
         if (aPathDepth < bPathDepth) {
           return 1;
         } else if (aPathDepth > bPathDepth) {

--- a/src/composer.js
+++ b/src/composer.js
@@ -237,11 +237,11 @@ export default class Composer extends EventEmitter {
       return this.createResourceSets({
         restApiId: restApi.data.id
       }).then(() => {
-        return restApi.data;
+        return restApi;
       });
     }).then((restApi) => {
       this.createDeployment({
-        restApiId: restApi.data.params.restApiId
+        restApiId: restApi.id
       });
     });
   }

--- a/src/composer.js
+++ b/src/composer.js
@@ -336,16 +336,14 @@ export default class Composer extends EventEmitter {
         statusCode: action.getStatusCode().toString()
       }).promise();
     }).then(() => {
-      return new Promise((resolve, reject) => {
-        new AWS.Lambda({
-          region: region
-        }).addPermission({
-          Action: 'lambda:InvokeFunction',
-          FunctionName: action.getName(),
-          Principal: 'apigateway.amazonaws.com',
-          StatementId: crypto.randomBytes(20).toString('hex')
-        }).promise();
-      })
+      return new AWS.Lambda({
+        region: region
+      }).addPermission({
+        Action: 'lambda:InvokeFunction',
+        FunctionName: action.getName(),
+        Principal: 'apigateway.amazonaws.com',
+        StatementId: crypto.randomBytes(20).toString('hex')
+      }).promise();
     }).then((value) => {
       this.emit(
         'methodSetUpdated',

--- a/src/composer.js
+++ b/src/composer.js
@@ -4,7 +4,6 @@ import crypto from 'crypto'
 import fs from 'fs'
 import glob from 'glob'
 import yazl from 'yazl'
-import { Client } from 'amazon-api-gateway-client'
 import { EventEmitter } from 'events'
 
 const DEFAULT_STAGE_NAME = 'production';

--- a/src/deploy_command.js
+++ b/src/deploy_command.js
@@ -13,8 +13,8 @@ export default class DeployCommand extends BaseCommand {
       secretAccessKey: AWS.config.credentials.secretAccessKey,
       application: new Application()
     })
-      .on('deploymentCreated', ({ restapiId, region, stageName }) => {
-        console.log(`Deployed: https://${restapiId}.execute-api.${region}.amazonaws.com/${stageName}`);
+      .on('deploymentCreated', ({ restApiId, region, stageName }) => {
+        console.log(`Deployed: https://${restApiId}.execute-api.${region}.amazonaws.com/${stageName}`);
       })
       .on('functionUploaded', ({ functionName }) => {
         console.log(`Uploaded function: ${functionName}`);
@@ -22,8 +22,8 @@ export default class DeployCommand extends BaseCommand {
       .on('methodSetUpdated', ({ httpMethod, path }) => {
         console.log(`Updated endpoint: ${httpMethod} ${path}`);
       })
-      .on('restapiCreated', ({ restapiId }) => {
-        console.log(`Created restapi: ${restapiId}`);
+      .on('restApiCreated', ({ restApiId }) => {
+        console.log(`Created restApi: ${restApiId}`);
       })
       .on('zipFileCreated', ({ zipPath }) => {
         console.log(`Created zip: ${zipPath}`);

--- a/src/deploy_command.js
+++ b/src/deploy_command.js
@@ -2,7 +2,6 @@ import AWS from 'aws-sdk'
 import Application from './application'
 import BaseCommand from './base_command'
 import Composer from './composer'
-import { Client } from 'amazon-api-gateway-client'
 
 /**
  * @class

--- a/src/deployments_command.js
+++ b/src/deployments_command.js
@@ -13,7 +13,7 @@ export default class RoutesCommand extends BaseCommand {
       accessKeyId: AWS.config.credentials.accessKeyId,
       secretAccessKey: AWS.config.credentials.secretAccessKey,
       region: application.getRegion()
-    }).listDeployments({ restapiId: application.getRestapiId() }).then((deployments) => {
+    }).listDeployments({ restApiId: application.getRestApiId() }).then((deployments) => {
       console.log(
         deployments.map((deployment) => {
           return `${deployment.source.id}  ${moment.unix(deployment.source.createdDate).format('YYYY-MM-DD HH:mm Z')}`;

--- a/src/deployments_command.js
+++ b/src/deployments_command.js
@@ -2,7 +2,6 @@ import AWS from 'aws-sdk'
 import Application from './application'
 import BaseCommand from './base_command'
 import moment from 'moment'
-import { Client } from 'amazon-api-gateway-client'
 
 /**
  * @class
@@ -10,7 +9,7 @@ import { Client } from 'amazon-api-gateway-client'
 export default class RoutesCommand extends BaseCommand {
   run() {
     const application = new Application();
-    new Client({
+    new AWS.APIGateway({
       accessKeyId: AWS.config.credentials.accessKeyId,
       secretAccessKey: AWS.config.credentials.secretAccessKey,
       region: application.getRegion()

--- a/src/open_command.js
+++ b/src/open_command.js
@@ -8,7 +8,7 @@ import open from 'open'
 export default class OpenCommand extends BaseCommand {
   run() {
     const application = new Application();
-    const url = `https://${application.getRestapiId()}.execute-api.${application.getRegion()}.amazonaws.com/production/`;
+    const url = `https://${application.getRestApiId()}.execute-api.${application.getRegion()}.amazonaws.com/production/`;
     console.log(url);
     open(url);
   }


### PR DESCRIPTION
This has biggish diff.

Dominantly modification:
- Absorb differences of API between `amazon-api-gateway-client` and `aws-sdk-promise`
- All `restapi(.*)` field is renamed `restApi\1` what AWS SDK uses
- Implement recursive resources creation that was handled it by `amazon-api-gateway-client`
