### PR TITLE
Support timeout setting

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -156,7 +156,7 @@ export default class Action {
    * @return {Integer}
    */
   getTimeout() {
-    return 60;
+    return this.getMetadata().fluct.timeout || 60;
   }
 
   /**


### PR DESCRIPTION
> your Lambda functions can now run for up to 5 minutes.

https://aws.amazon.com/jp/blogs/aws/aws-lambda-update-python-vpc-increased-function-duration-scheduling-and-more/
