### PR TITLE
Add a target to include static binaries in a zipped package

### DIFF
--- a/src/composer.js
+++ b/src/composer.js
@@ -203,6 +203,11 @@ export default class Composer extends EventEmitter {
           zipFile.addFile(path, path);
         }
       });
+      glob.sync(`./bin/*`).forEach((path) => {
+        if (!fs.lstatSync(path).isDirectory()) {
+          zipFile.addFile(path, path);
+        }
+      });
       zipFile.outputStream.pipe(
         fs.createWriteStream(zipPath)
       ).on('close', () => {


### PR DESCRIPTION
In some case, I often needed to use a static binary like ffmpeg.

So, I want to add ./bin/\* as zipped target.

If ffmpeg static binrary is in ./bin/*, we can execute ffmpeg in ./actions/index.js like the below example.

```
var child_process = require('child_process');
exports.handler = function (event, context) {
    var ffmpegPath = '';
    if (!process.env.NODE_ENV || process.env.NODE_ENV != 'development') {
        // production
        ffmpegPath = './bin/ffmpeg';
    } else {
        // development
        ffmpegPath = '../bin/ffmpeg';
    }
    child_process.execFile(
       ffmpegPath,
      [
        '-y',
        '-i', 'input.mp4',
        'output.avi'
      ],
      function(err, stdout, stderr) {
        console.log(err, stdout, stderr);
      }
    );
}
```
