### PR TITLE
Set default runtime to nodejs4.3

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -169,6 +169,13 @@ export default class Action {
   /**
    * @return {String}
    */
+  getRuntime() {
+    return this.getMetadata().fluct.runtime || 'nodejs4.3';
+  }
+
+  /**
+   * @return {String}
+   */
   getUri() {
     return `arn:aws:apigateway:${this.application.getRegion()}:lambda:path/2015-03-31/functions/${this.getFunctionArn()}/invocations`;
   }

--- a/src/composer.js
+++ b/src/composer.js
@@ -392,7 +392,7 @@ export default class Composer extends EventEmitter {
    * @param {String} zipPath
    * @return {Promise}
    */
-  uploadAction({ functionName, handlerId, region, roleArn, timeout, memorySize, zipPath, }) {
+  uploadAction({ functionName, handlerId, region, roleArn, timeout, memorySize, zipPath, runtime, }) {
     return new Promise((resolve, reject) => {
       awsLambda.deploy(
         zipPath,
@@ -402,7 +402,8 @@ export default class Composer extends EventEmitter {
           region: region,
           role: roleArn,
           timeout: timeout,
-          memorySize: memorySize
+          memorySize: memorySize,
+          runtime: runtime
         },
         (error) => {
           if (error) {
@@ -431,7 +432,8 @@ export default class Composer extends EventEmitter {
           functionName: action.getName(),
           handlerId: action.getHandlerId(),
           timeout: action.getTimeout(),
-          memorySize: action.getMemorySize()
+          memorySize: action.getMemorySize(),
+          runtime: action.getRuntime()
         });
       })
     );


### PR DESCRIPTION
I've added action's package.json directive called `runtime` which defaults to `nodejs4.3`.

It's passed to https://github.com/ThoughtWorksStudios/node-aws-lambda/blob/cfc0864353153689ee2c389041093a917e3b40f6/index.js#L138 and eventually to http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Lambda.html#createFunction-property

Whether it should be `nodejs` or `nodejs4.3` is arguable. I think `nodejs4.3` is the better choice because AWS console warns us not to use nodejs 0.10 any more.

<img width="721" alt="lambda_management_console" src="https://cloud.githubusercontent.com/assets/28143/14988539/37e58796-118f-11e6-9409-ed7af777f50b.png">

People who already use fluct is not affected by this default value because the runtime setting only affects when the zip is uploaded for the first time, although the behavior depends on node-aws-lambda's implementation ( https://github.com/ThoughtWorksStudios/node-aws-lambda/blob/cfc0864353153689ee2c389041093a917e3b40f6/index.js#L155-L165 ) 
